### PR TITLE
fix(home): eliminate mobile horizontal overflow on the home page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,11 +41,20 @@
 html {
   scroll-behavior: smooth;
   font-family: var(--font-sans);
+  /* Viewport-level safety net: if any decoration (radial glow, wide
+     <pre>, unexpectedly wide image) sticks past the viewport edge,
+     contain it horizontally rather than letting the page widen and
+     get horizontal scroll — which on mobile made the fixed <Nav>
+     appear narrower than the body content.
+     `clip` instead of `hidden` so `position: sticky` descendants
+     keep working (hidden would force a scroll container). */
+  overflow-x: clip;
 }
 body {
   font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  overflow-x: clip;
 }
 
 /* visible focus rings for accessibility */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -253,8 +253,14 @@ export default function HomePage() {
               <p className="text-center sm:text-left text-xl font-semibold pt-3">No blind trust. No hope. <span className="gradient-text">Cryptographic proof.</span></p>
             </ol>
 
-            <div className="relative reveal">
-              <div className="absolute -inset-10 hero-glow" />
+            <div className="relative reveal min-w-0">
+              {/* Glow wrapper clips its own pseudo-element so the
+                  hero-glow::before (which extends -10% beyond) cannot
+                  escape the grid column and force horizontal page
+                  overflow on mobile. */}
+              <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                <div className="absolute -inset-10 hero-glow" />
+              </div>
               <div className="relative mx-auto w-full max-w-sm card rounded-[2.5rem] p-3">
                 <div className="rounded-[2rem] overflow-hidden bg-neutral-50 dark:bg-neutral-900">
                   <div className="h-6 flex items-center justify-center bg-neutral-100 dark:bg-neutral-800/60"><span className="w-16 h-1.5 rounded-full bg-neutral-300 dark:bg-neutral-700" /></div>
@@ -361,7 +367,7 @@ Response: Connected, with scoped access.   Audit record written.`}</pre>
                   <p className="text-neutral-900 dark:text-white font-semibold">Your infrastructure. Your data. Your rules.</p>
                 </div>
               </div>
-              <div className="card rounded-2xl p-5 text-sm">
+              <div className="card rounded-2xl p-5 text-sm min-w-0">
                 <div className="flex items-center justify-between mb-3 text-xs text-neutral-500">
                   <div className="flex gap-1.5"><span className="w-2.5 h-2.5 rounded-full bg-red-400" /><span className="w-2.5 h-2.5 rounded-full bg-amber-400" /><span className="w-2.5 h-2.5 rounded-full bg-emerald-400" /></div>
                   <span className="font-mono">agent-pack.yaml</span>


### PR DESCRIPTION
On mobile the home page was laying out slightly wider than the viewport, which made the `fixed` `<Nav>` appear narrower than the body content (the header is locked to `inset-x-0` at the original viewport width while the body stretches to accommodate whatever is overflowing). Three cooperating causes, fixed together.

## Root causes

### 1. `.hero-glow::before` escapes horizontally in the Proof-of-Trust section

```tsx
<div className="relative reveal">
  <div className="absolute -inset-10 hero-glow" />
  ...
</div>
```

- `-inset-10` extends the glow div 40 px beyond the grid column in all directions.
- `.hero-glow::before` adds another `inset: -10% -10% auto -10%` on top of that.
- Neither the `.relative.reveal` parent nor any ancestor up to `<body>` has `overflow-hidden`.

Net effect on a ~375 px mobile viewport: the glow sticks ~30 px past the right edge → body stretches → horizontal scroll → `<Nav>` looks narrower than the body. Classic bug.

### 2. Long `<pre>` forces grid columns wider than their container

Classic CSS Grid gotcha: direct grid children default to `min-width: auto`, so a `<pre>`'s intrinsic min-content (its longest line) bypasses `overflow-x-auto` and forces the column wider than the `max-w-7xl` container. Two places on the home page:

- Pillar 1 — `agent-pack.yaml` block (long lines like `- { credential: Employee, tools: ["*"], stepUp: [refund] }`, ~60 chars at 13 px mono ≈ 390 px, wider than a 375 px viewport)
- Proof of Trust — JSON result block

### 3. No viewport-level safety net

Neither `<html>` nor `<body>` had `overflow-x`. Any future element overflowing by even one pixel (a new glow, a wide code snippet, a panoramic logo) would regress the same bug. No belt, no suspenders.

## Fixes

### `src/app/globals.css`

```css
html {
  ...
  overflow-x: clip;
}
body {
  ...
  overflow-x: clip;
}
```

Belt-and-suspenders safety net at the root. `clip` instead of `hidden` because `hidden` would force either element to become a scroll container, which breaks any descendant `position: sticky` and interacts weirdly with `position: fixed` on iOS Safari. `overflow-x: clip` simply clips visually without creating a scroll container — supported in all current evergreen browsers (Chrome 90+, Safari 16+, Firefox 81+).

### `src/app/page.tsx:256` — Proof-of-Trust right column

```diff
- <div className="relative reveal">
-   <div className="absolute -inset-10 hero-glow" />
+ <div className="relative reveal min-w-0">
+   <div className="absolute inset-0 overflow-hidden pointer-events-none">
+     <div className="absolute -inset-10 hero-glow" />
+   </div>
```

- Wraps the glow decoration in its own `absolute inset-0 overflow-hidden` clipper, so `-inset-10` plus `::before`'s `-10%` can no longer escape the grid column — the glow still renders at its intended look, it just can't spill past the column bounds.
- `min-w-0` on the grid child itself so the inner `<pre>` (the JSON block) can't force the column wider.

### `src/app/page.tsx:370` — Pillar 1 agent-pack.yaml column

```diff
- <div className="card rounded-2xl p-5 text-sm">
+ <div className="card rounded-2xl p-5 text-sm min-w-0">
```

Same `min-w-0` fix on the Pillar 1 card that hosts the YAML `<pre>`. Now the `overflow-x-auto` on the `<pre>` actually does its job — scrolls internally instead of pushing the grid column wide.

## Why not just `overflow-x: hidden` on `<body>` and call it a day?

Because then any future decoration that genuinely needs to extend past the column would get silently clipped without the author knowing. The targeted fixes clip precisely where clipping is intended (the glow wrapper) and mark the grid columns with `min-w-0` so intrinsic content stays within their grid track. The body-level `overflow-x: clip` is only there to catch anything we miss.

## Verification

- `npm run build` — passes, all routes prerender static, bundle sizes unchanged
- Locally: Chrome DevTools at 375 px viewport on the home page — `document.documentElement.scrollWidth === document.documentElement.clientWidth` (was ~15 px larger before)
- Other pages unaffected: the body-level `overflow-x: clip` is a no-op on pages that weren't overflowing

## Follow-ups not in this PR

If we spot mobile overflow on any other page, the fix pattern is the same:

1. Add `overflow-hidden` around any absolute decoration that uses negative insets
2. Add `min-w-0` to any grid column that hosts a `<pre>` or other min-content-wide block
3. The viewport-level `overflow-x: clip` already catches the rest