### PR TITLE
feat(demos): revamp demo cards with real icons, single-QR, phone/desktop routing

### DIFF
--- a/src/app/demos/page.tsx
+++ b/src/app/demos/page.tsx
@@ -71,6 +71,12 @@ export default function DemosPage() {
                 </Link>
                 .
               </p>
+              <p className="mt-3">
+                These demos are educational. Each one is scoped to a single
+                capability so the underlying concept is easy to follow. In
+                a real deployment, one agent usually combines several of
+                these capabilities into a single Agent Pack.
+              </p>
             </div>
           </div>
         </div>

--- a/src/app/demos/page.tsx
+++ b/src/app/demos/page.tsx
@@ -1,8 +1,11 @@
+import Link from "next/link";
+import DemoGrid from "@/components/DemoGrid";
 import { buildPageMetadata } from "@/lib/metadata";
 
 export const metadata = buildPageMetadata({
   title: "Demos",
-  description: "Live demos of Hologram agents: Avatar, Government Digital ID, GitHub, Wise, and X. Real trust resolution, real credentials, try them now.",
+  description:
+    "Live demos of Hologram agents: Avatar, Passport, GitHub, Wise, and X. Real trust resolution, real credentials, try them now.",
   path: "/demos",
 });
 
@@ -13,107 +16,66 @@ export default function DemosPage() {
       <section className="hero-glow relative overflow-hidden">
         <div className="absolute inset-0 bg-grid pointer-events-none" />
         <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-12 md:pt-28 text-center">
-          <span className="inline-block text-xs font-semibold tracking-widest uppercase text-brand-600 dark:text-brand-400">Live demos</span>
-          <h1 className="font-display h-display mt-3">See It <span className="gradient-text">Live.</span></h1>
-          <p className="mt-5 text-lg md:text-xl text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">Real agents. Real credentials. Real trust resolution. Try them now.</p>
-          <p className="mt-4 text-sm text-neutral-500 max-w-2xl mx-auto">Every demo is open source, deployed as a Verifiable Service on the Verana network, and available for you to try right now with the Hologram app.</p>
+          <span className="inline-block text-xs font-semibold tracking-widest uppercase text-brand-600 dark:text-brand-400">
+            Live demos
+          </span>
+          <h1 className="font-display h-display mt-3">
+            See It <span className="gradient-text">Live.</span>
+          </h1>
+          <p className="mt-5 text-lg md:text-xl text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">
+            Real agents. Real credentials. Real trust resolution. Try them now.
+          </p>
+          <p className="mt-4 text-sm text-neutral-500 max-w-2xl mx-auto">
+            Every demo is open source, deployed as a Verifiable Service on the
+            Verana network, and available for you to try right now with the
+            Hologram app.
+          </p>
         </div>
       </section>
 
       {/* ============== DEMO GRID ============== */}
       <section className="py-20 border-t border-neutral-200 dark:border-white/10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid md:grid-cols-2 gap-6">
-
-          {/* Demo 1: Avatar */}
-          <article className="card rounded-2xl p-6 reveal flex flex-col">
-            <div className="h-40 rounded-xl bg-gradient-to-br from-brand-500/30 via-blue-500/20 to-cyan-500/20 flex items-center justify-center mb-5 relative overflow-hidden">
-              <div className="absolute inset-0 bg-grid opacity-40" />
-              <div className="relative w-20 h-20 rounded-full bg-gradient-to-br from-brand-500 to-blue-500 flex items-center justify-center text-white font-bold text-2xl">@</div>
-              <span className="absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-500 text-[10px] font-semibold">✔ verified</span>
+        {/* App prerequisite notice — shown once, above every card. */}
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-10">
+          <div className="rounded-2xl border border-brand-500/25 bg-brand-500/5 dark:bg-brand-500/10 p-5 md:p-6 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+            <div
+              aria-hidden="true"
+              className="shrink-0 w-12 h-12 rounded-xl bg-gradient-to-br from-brand-500 to-blue-500 flex items-center justify-center text-white"
+            >
+              <svg
+                className="w-6 h-6"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="6" y="2" width="12" height="20" rx="3" />
+                <path d="M11 18h2" />
+              </svg>
             </div>
-            <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">Demo 1</div>
-            <h2 className="font-display text-2xl font-bold mt-1">Avatar · Your Digital Identity</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed"><strong className="text-neutral-900 dark:text-white">Create your verifiable avatar in minutes.</strong> Choose a name, upload a photo, and receive a Verifiable Credential that represents you across the entire ecosystem. Protect it with a password or authenticator app. Lose your phone? Recover it anytime.</p>
-            <p className="mt-3 text-sm text-neutral-500">Your avatar is yours: portable, verifiable, and under your control.</p>
-            <div className="mt-5 flex gap-2">
-              <a href="#" className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition">Try It</a>
-              <a href="https://github.com/2060-io" className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition">GitHub ↗</a>
+            <div className="flex-1 text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">
+              <p className="font-semibold text-neutral-900 dark:text-white">
+                You&apos;ll need the Hologram app to try these demos.
+              </p>
+              <p className="mt-1">
+                Every demo connects over DIDComm with{" "}
+                <strong className="text-neutral-900 dark:text-white">
+                  Hologram Messaging
+                </strong>{" "}
+                on your phone. If you don&apos;t have it yet, grab it from the{" "}
+                <Link
+                  href="/apps"
+                  className="text-brand-600 dark:text-brand-400 hover:underline font-semibold"
+                >
+                  Apps page
+                </Link>
+                {" "}— it&apos;s free on iOS and Android.
+              </p>
             </div>
-          </article>
-
-          {/* Demo 2: Government Digital ID */}
-          <article className="card rounded-2xl p-6 reveal flex flex-col">
-            <div className="h-40 rounded-xl bg-gradient-to-br from-emerald-500/25 via-blue-500/15 to-brand-500/15 flex items-center justify-center mb-5 relative overflow-hidden">
-              <div className="absolute inset-0 bg-grid opacity-40" />
-              <svg className="relative w-20 h-20 text-emerald-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="2" y="5" width="20" height="14" rx="2" /><circle cx="8" cy="12" r="3" /><path d="M14 10h5M14 14h3" /></svg>
-              <span className="absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-500 text-[10px] font-semibold">NFC + liveness</span>
-            </div>
-            <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">Demo 2</div>
-            <h2 className="font-display text-2xl font-bold mt-1">Government Digital ID</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed"><strong className="text-neutral-900 dark:text-white">Get a digital identity credential from your passport.</strong> Scan the NFC chip in your passport or ID card. Complete a liveness check. The agent compares your face to the document photo in real time. If everything matches, you receive a Government Digital ID credential you can use anywhere.</p>
-            <p className="mt-3 text-sm text-neutral-500">Production-grade identity verification. Open source.</p>
-            <div className="mt-5 flex gap-2">
-              <a href="#" className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition">Try It</a>
-              <a href="https://github.com/2060-io" className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition">GitHub ↗</a>
-            </div>
-          </article>
-
-          {/* Demo 3: GitHub */}
-          <article className="card rounded-2xl p-6 reveal flex flex-col">
-            <div className="h-40 rounded-xl bg-gradient-to-br from-neutral-800 via-neutral-900 to-black flex items-center justify-center mb-5 relative overflow-hidden border border-white/10">
-              <div className="absolute inset-0 bg-grid opacity-30" />
-              <svg className="relative w-16 h-16 text-white" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 00-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.4-4-1.4-.6-1.4-1.4-1.8-1.4-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 011.2-3.2c-.1-.3-.5-1.5.2-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 016 0C17.3 4.7 18.3 5 18.3 5c.7 1.7.2 2.9.1 3.2a4.7 4.7 0 011.2 3.2c0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0012 .3" /></svg>
-              <span className="absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-500/20 text-brand-300 text-[10px] font-semibold">MCP-powered</span>
-            </div>
-            <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">Demo 3</div>
-            <h2 className="font-display text-2xl font-bold mt-1">GitHub Agent</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed"><strong className="text-neutral-900 dark:text-white">Your AI-powered GitHub assistant.</strong> Search repositories, browse issues and pull requests, explore code, all through a verified AI agent in a private chat. Connect your own GitHub account securely, and the agent works on your behalf. Multi-language, instant responses, every interaction private.</p>
-            <div className="mt-5 flex gap-2">
-              <a href="#" className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition">Try It</a>
-              <a href="https://github.com/2060-io" className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition">GitHub ↗</a>
-            </div>
-          </article>
-
-          {/* Demo 4: Wise */}
-          <article className="card rounded-2xl p-6 reveal flex flex-col">
-            <div className="h-40 rounded-xl bg-gradient-to-br from-emerald-500/30 via-cyan-500/20 to-blue-500/20 flex items-center justify-center mb-5 relative overflow-hidden">
-              <div className="absolute inset-0 bg-grid opacity-40" />
-              <div className="relative card rounded-xl p-3 w-44 text-xs">
-                <div className="text-[10px] text-neutral-500 uppercase tracking-widest">Balance</div>
-                <div className="flex items-center justify-between mt-1"><span className="font-semibold">EUR</span><span>€1,284.50</span></div>
-                <div className="flex items-center justify-between mt-1"><span className="font-semibold">USD</span><span>$940.12</span></div>
-                <div className="flex items-center justify-between mt-1"><span className="font-semibold">GBP</span><span>£712.30</span></div>
-              </div>
-              <span className="absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-cyan-500/20 text-cyan-300 text-[10px] font-semibold">financial</span>
-            </div>
-            <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">Demo 4</div>
-            <h2 className="font-display text-2xl font-bold mt-1">Wise Financial Agent</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed"><strong className="text-neutral-900 dark:text-white">Manage your international finances through a trusted AI.</strong> Check balances, review transfers, get live exchange rates, all through a verified AI agent connected to your Wise account. Authenticate with your credential, link your own Wise token securely, and manage your money through conversation.</p>
-            <div className="mt-5 flex gap-2">
-              <a href="#" className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition">Try It</a>
-              <a href="https://github.com/2060-io" className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition">GitHub ↗</a>
-            </div>
-          </article>
-
-          {/* Demo 5: X Agent */}
-          <article className="card rounded-2xl p-6 reveal flex flex-col md:col-span-2">
-            <div className="h-44 rounded-xl bg-gradient-to-br from-amber-400/30 via-pink-500/25 to-brand-500/30 flex items-center justify-center mb-5 relative overflow-hidden">
-              <div className="absolute inset-0 bg-grid opacity-30" />
-              <div className="relative flex items-center gap-4">
-                <svg className="w-12 h-12 text-white" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2H21l-6.54 7.47L22 22h-6.828l-5.34-6.982L3.6 22H1l7.02-8.02L1 2h7.005l4.833 6.39L18.244 2zm-2.39 18h1.64L6.22 4H4.47l11.383 16z" /></svg>
-                <div className="text-white font-display text-xl font-bold">Compose. Draw. Publish.</div>
-              </div>
-              <span className="absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-pink-500/30 text-pink-200 text-[10px] font-semibold">creative</span>
-            </div>
-            <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">Demo 5</div>
-            <h2 className="font-display text-2xl font-bold mt-1">X (Twitter) Agent</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed max-w-3xl"><strong className="text-neutral-900 dark:text-white">Compose, publish, and manage your social media, with AI that can draw.</strong> Draft tweets, search posts, manage your timeline, and generate images for your posts on the fly. The agent writes, you review and approve before anything goes live. Voice notes welcome: just talk, and the agent transcribes and acts.</p>
-            <div className="mt-5 flex gap-2">
-              <a href="#" className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition">Try It</a>
-              <a href="https://github.com/2060-io" className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition">GitHub ↗</a>
-            </div>
-          </article>
+          </div>
         </div>
+
+        <DemoGrid />
       </section>
     </>
   );

--- a/src/app/demos/page.tsx
+++ b/src/app/demos/page.tsx
@@ -69,7 +69,7 @@ export default function DemosPage() {
                 >
                   Apps page
                 </Link>
-                {" "}— it&apos;s free on iOS and Android.
+                .
               </p>
             </div>
           </div>

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -65,6 +65,11 @@ const DEMOS: Demo[] = [
         flow, and receive a Verifiable Credential backed by the Verana
         Trust Registry. Your credential proves attributes about you and can
         be verified by any party.
+        <br />
+        <br />
+        <strong className="text-neutral-900 dark:text-white">Start here.</strong>{" "}
+        The Avatar credential is required to authenticate with the GitHub
+        Agent, Wise Agent and X Agent demos below.
       </>
     ),
     endpoint: "https://avatar.vs.hologram.zone",

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -105,7 +105,7 @@ const DEMOS: Demo[] = [
     title: "GitHub Agent",
     tagline: "AI assistant over MCP",
     badge: {
-      label: "Community Service",
+      label: "Multiuser Service",
       className:
         "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300 ring-1 ring-cyan-500/30",
     },
@@ -138,7 +138,7 @@ const DEMOS: Demo[] = [
     title: "Wise Agent",
     tagline: "AI assistant over MCP",
     badge: {
-      label: "Community Service",
+      label: "Multiuser Service",
       className:
         "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300 ring-1 ring-cyan-500/30",
     },

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/* -------------------------------------------------------------------------- */
+/*  Demo data                                                                 */
+/*                                                                            */
+/*  Descriptions, endpoints and logos mirror the Verifiable Services          */
+/*  playground (hologram-verifiable-services/playground/app/page.tsx).        */
+/*  If you change anything here, consider keeping the playground in sync.     */
+/* -------------------------------------------------------------------------- */
+
+type Demo = {
+  id: string;
+  title: string;
+  /** One-line subtitle shown below the title. */
+  tagline?: string;
+  /** Badge text + color classes. */
+  badge: {
+    label: string;
+    className: string;
+  };
+  /** Card hero artwork. Either an image URL, or a custom node for demos
+   *  that don't have a playground icon yet (the X Agent). */
+  art:
+    | { kind: "photo"; src: string; alt: string; gradient: string }
+    | { kind: "logo"; src: string; alt: string; gradient: string }
+    | { kind: "node"; node: React.ReactNode; gradient: string };
+  description: React.ReactNode;
+  /** Public URL of the deployed Verifiable Service.
+   *  `{endpoint}/qr` serves the DIDComm invitation QR.
+   *  `{endpoint}/invitation` is the mobile-friendly landing page that
+   *  triggers the Hologram Messaging deep-link. */
+  endpoint?: string;
+  /** For demos that can't be tried directly (e.g. the X Agent), the
+   *  primary CTA becomes a deploy-it-yourself link. */
+  deployYourOwn?: { href: string; label: string };
+  githubUrl: string;
+  /** When true, the card spans both columns on md+. */
+  wide?: boolean;
+};
+
+const DEMOS: Demo[] = [
+  {
+    id: "avatar",
+    title: "Avatar",
+    tagline: "Your Digital Identity",
+    badge: {
+      label: "Human Credential Issuer",
+      className:
+        "bg-brand-500/15 text-brand-700 dark:text-brand-300 ring-1 ring-brand-500/30",
+    },
+    art: {
+      kind: "photo",
+      src: "https://2060.io/images/avatar.jpg",
+      alt: "Avatar service",
+      gradient:
+        "bg-gradient-to-br from-brand-500/30 via-blue-500/20 to-cyan-500/20",
+    },
+    description: (
+      <>
+        A <strong className="text-neutral-900 dark:text-white">DIDComm chatbot</strong>{" "}
+        that issues verifiable credentials to users through conversational
+        interactions. Connect with Hologram Messaging, follow the guided
+        flow, and receive a W3C Verifiable Credential backed by the Verana
+        Trust Registry. Your credential proves attributes about you and can
+        be verified by any party.
+      </>
+    ),
+    endpoint: "https://avatar.vs.hologram.zone",
+    githubUrl: "https://github.com/2060-io/hologram-verifiable-services",
+  },
+  {
+    id: "passport",
+    title: "Passport",
+    tagline: "Government Digital ID",
+    badge: {
+      label: "Human Credential Issuer",
+      className:
+        "bg-brand-500/15 text-brand-700 dark:text-brand-300 ring-1 ring-brand-500/30",
+    },
+    art: {
+      kind: "photo",
+      src: "/images/passport.jpg",
+      alt: "Passport issuer",
+      gradient:
+        "bg-gradient-to-br from-emerald-500/25 via-blue-500/15 to-brand-500/15",
+    },
+    description: (
+      <>
+        A credential issuer that reads{" "}
+        <strong className="text-neutral-900 dark:text-white">NFC data</strong>{" "}
+        from government-issued identity documents (passports, ID cards) and
+        verifies the holder&apos;s identity via a liveness check with video
+        call and gesture detection. Once verified, it issues a passport
+        credential as a W3C Verifiable Credential backed by the Verana Trust
+        Registry.
+      </>
+    ),
+    endpoint: "https://passport.vs.hologram.zone",
+    githubUrl: "https://github.com/2060-io/hologram-verifiable-services",
+  },
+  {
+    id: "github-agent",
+    title: "GitHub Agent",
+    tagline: "AI assistant over MCP",
+    badge: {
+      label: "Community Service",
+      className:
+        "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300 ring-1 ring-cyan-500/30",
+    },
+    art: {
+      kind: "logo",
+      src: "/images/github.svg",
+      alt: "GitHub",
+      gradient:
+        "bg-gradient-to-br from-neutral-800 via-neutral-900 to-black",
+    },
+    description: (
+      <>
+        An AI-powered GitHub assistant that uses the{" "}
+        <strong className="text-neutral-900 dark:text-white">Model Context Protocol (MCP)</strong>{" "}
+        to interact with GitHub on your behalf. Search repositories, browse
+        issues and pull requests, explore code, and manage your projects —
+        all through an encrypted DIDComm chat in Hologram Messaging. To get
+        started: first authenticate using the credential you received from
+        the Avatar service, then open the contextual menu, select{" "}
+        <em>MCP Server Config</em>, and enter your GitHub Personal Access
+        Token. Once configured, the agent can access GitHub tools on your
+        behalf.
+      </>
+    ),
+    endpoint: "https://github-agent.vs.hologram.zone",
+    githubUrl: "https://github.com/2060-io/hologram-verifiable-services",
+  },
+  {
+    id: "wise-agent",
+    title: "Wise Agent",
+    tagline: "AI assistant over MCP",
+    badge: {
+      label: "Community Service",
+      className:
+        "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300 ring-1 ring-cyan-500/30",
+    },
+    art: {
+      kind: "logo",
+      src: "/images/wise.svg",
+      alt: "Wise",
+      gradient:
+        "bg-gradient-to-br from-emerald-500/30 via-cyan-500/20 to-blue-500/20",
+    },
+    description: (
+      <>
+        An AI-powered Wise assistant that uses the{" "}
+        <strong className="text-neutral-900 dark:text-white">Model Context Protocol (MCP)</strong>{" "}
+        to interact with your Wise account. Check balances, view exchange
+        rates, list transfers, send money, create invoices, and manage
+        recipients — all through an encrypted DIDComm chat in Hologram
+        Messaging. To get started: first authenticate using the credential
+        you received from the Avatar service, then open the contextual menu,
+        select <em>MCP Server Config</em>, and enter your Wise API Token.
+        Once configured, the agent can access Wise tools on your behalf.
+      </>
+    ),
+    endpoint: "https://wise-agent.vs.hologram.zone",
+    githubUrl: "https://github.com/2060-io/hologram-verifiable-services",
+  },
+  {
+    id: "x-agent",
+    title: "X (Twitter) Agent",
+    tagline: "Compose · Draw · Publish",
+    badge: {
+      label: "Personal or Corporate Service",
+      className:
+        "bg-amber-500/15 text-amber-700 dark:text-amber-300 ring-1 ring-amber-500/30",
+    },
+    art: {
+      kind: "node",
+      gradient:
+        "bg-gradient-to-br from-amber-400/30 via-pink-500/25 to-brand-500/30",
+      node: (
+        <div className="relative flex items-center gap-4">
+          <svg
+            className="w-12 h-12 text-white"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M18.244 2H21l-6.54 7.47L22 22h-6.828l-5.34-6.982L3.6 22H1l7.02-8.02L1 2h7.005l4.833 6.39L18.244 2zm-2.39 18h1.64L6.22 4H4.47l11.383 16z" />
+          </svg>
+          <div className="text-white font-display text-xl font-bold">
+            Compose. Draw. Publish.
+          </div>
+        </div>
+      ),
+    },
+    description: (
+      <>
+        <strong className="text-neutral-900 dark:text-white">
+          Compose, publish, and manage your social media with an AI that can
+          draw.
+        </strong>{" "}
+        Draft tweets, search posts, manage your timeline, and generate images
+        for your posts on the fly. The agent writes, you review and approve
+        before anything goes live. Voice notes welcome: just talk, and the
+        agent transcribes and acts.
+        <br />
+        <br />
+        Because each instance is tied to a specific X/Twitter account, there
+        is no shared demo — you deploy your own, linked to your own handle.
+        See the documentation to get started.
+      </>
+    ),
+    deployYourOwn: {
+      href: "https://docs.hologram.zone",
+      label: "Deploy Your Own",
+    },
+    githubUrl: "https://github.com/2060-io/x-autonomous-mcp",
+    wide: true,
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  Device detection                                                          */
+/*                                                                            */
+/*  Phones → redirect straight to `${endpoint}/invitation`, which triggers    */
+/*  the Hologram Messaging deep-link on the user's device.                    */
+/*  Tablets + desktops → show a QR code inline; the user scans it with        */
+/*  Hologram Messaging on their phone.                                        */
+/*                                                                            */
+/*  The regex matches true phone UAs only:                                    */
+/*    - iPhone / iPod                                                         */
+/*    - Android phones (the "Mobile" token; Android tablets omit it)          */
+/*    - BlackBerry, IEMobile, Opera Mini                                      */
+/*  Deliberately not matched:                                                 */
+/*    - iPad — on iPadOS 13+ reports as "Macintosh"                           */
+/*    - Android tablets — UA has "Android" but no "Mobile"                    */
+/* -------------------------------------------------------------------------- */
+
+const PHONE_UA_RE =
+  /(iPhone|iPod|Android.*Mobile|IEMobile|BlackBerry|Opera Mini)/i;
+
+function isPhone(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return PHONE_UA_RE.test(navigator.userAgent);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  DemoGrid — holds the "which QR is open" state so only one QR shows        */
+/*  at a time across every card.                                              */
+/* -------------------------------------------------------------------------- */
+
+export default function DemoGrid() {
+  const [openQrId, setOpenQrId] = useState<string | null>(null);
+
+  const handleTryIt = useCallback((demo: Demo) => {
+    if (!demo.endpoint) return;
+    // Phones: send the user straight to the service's invitation page,
+    // which triggers the Hologram Messaging deep-link.
+    if (isPhone()) {
+      window.location.href = `${demo.endpoint}/invitation`;
+      return;
+    }
+    // Tablets / desktops: toggle the inline QR. Opening one QR closes
+    // any other currently-open QR (single-open invariant).
+    setOpenQrId((current) => (current === demo.id ? null : demo.id));
+  }, []);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid md:grid-cols-2 gap-6">
+      {DEMOS.map((demo, i) => (
+        <DemoCard
+          key={demo.id}
+          demo={demo}
+          index={i}
+          isQrOpen={openQrId === demo.id}
+          onTryIt={() => handleTryIt(demo)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Single demo card                                                          */
+/* -------------------------------------------------------------------------- */
+
+function DemoCard({
+  demo,
+  index,
+  isQrOpen,
+  onTryIt,
+}: {
+  demo: Demo;
+  index: number;
+  isQrOpen: boolean;
+  onTryIt: () => void;
+}) {
+  return (
+    <article
+      className={`card rounded-2xl p-6 reveal flex flex-col min-w-0 ${
+        demo.wide ? "md:col-span-2" : ""
+      }`}
+    >
+      {/* Hero artwork */}
+      <div
+        className={`h-40 rounded-xl ${demo.art.gradient} flex items-center justify-center mb-5 relative overflow-hidden`}
+      >
+        <div className="absolute inset-0 bg-grid opacity-40" />
+        {demo.art.kind === "photo" && (
+          <img
+            src={demo.art.src}
+            alt={demo.art.alt}
+            className="relative w-24 h-24 rounded-2xl object-cover shadow-xl ring-1 ring-white/30"
+            loading="lazy"
+          />
+        )}
+        {demo.art.kind === "logo" && (
+          <img
+            src={demo.art.src}
+            alt={demo.art.alt}
+            className="relative w-20 h-20 rounded-2xl object-contain bg-white p-3 shadow-xl"
+            loading="lazy"
+          />
+        )}
+        {demo.art.kind === "node" && demo.art.node}
+        <span
+          className={`absolute bottom-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold ${demo.badge.className}`}
+        >
+          {demo.badge.label}
+        </span>
+      </div>
+
+      {/* Meta + title */}
+      <div className="text-xs uppercase tracking-widest text-brand-600 dark:text-brand-400 font-semibold">
+        Demo {index + 1}
+      </div>
+      <h2 className="font-display text-2xl font-bold mt-1">
+        {demo.title}
+        {demo.tagline && (
+          <span className="text-neutral-500 dark:text-neutral-400 font-normal">
+            {" · "}
+            {demo.tagline}
+          </span>
+        )}
+      </h2>
+
+      {/* Description */}
+      <div className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed">
+        {demo.description}
+      </div>
+
+      {/* Actions */}
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        {demo.endpoint ? (
+          <button
+            type="button"
+            onClick={onTryIt}
+            aria-expanded={isQrOpen}
+            aria-controls={`qr-${demo.id}`}
+            className={`px-4 py-2 rounded-lg text-sm font-semibold transition ${
+              isQrOpen
+                ? "bg-neutral-900 text-white hover:bg-neutral-800"
+                : "bg-brand-600 hover:bg-brand-500 text-white"
+            }`}
+          >
+            {isQrOpen ? "Hide QR" : "Try It"}
+          </button>
+        ) : demo.deployYourOwn ? (
+          <a
+            href={demo.deployYourOwn.href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="px-4 py-2 rounded-lg text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white transition"
+          >
+            {demo.deployYourOwn.label} ↗
+          </a>
+        ) : null}
+        <a
+          href={demo.githubUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="px-4 py-2 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/5 transition"
+        >
+          GitHub ↗
+        </a>
+      </div>
+
+      {/* QR panel — only rendered for demos with an endpoint, only shown
+          on tablet/desktop after the user clicks "Try It". */}
+      {isQrOpen && demo.endpoint && (
+        <div
+          id={`qr-${demo.id}`}
+          className="mt-5 border-t border-neutral-200 dark:border-white/10 pt-5"
+        >
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-white rounded-2xl p-3 shadow-sm">
+              <img
+                src={`${demo.endpoint}/qr`}
+                alt={`QR code to connect with ${demo.title}`}
+                width={220}
+                height={220}
+                className="block w-[220px] h-[220px]"
+              />
+            </div>
+            <p className="text-xs text-neutral-500 text-center max-w-xs">
+              Scan with{" "}
+              <strong className="text-neutral-700 dark:text-neutral-200">
+                Hologram Messaging
+              </strong>{" "}
+              to connect with {demo.title}.
+            </p>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -208,6 +208,17 @@ const DEMOS: Demo[] = [
         Because each instance is tied to a specific X/Twitter account, there
         is no shared demo — you deploy your own, linked to your own handle.
         See the documentation to get started.
+        <br />
+        <br />
+        Once deployed, you decide{" "}
+        <strong className="text-neutral-900 dark:text-white">
+          who is allowed to post in the name of the account
+        </strong>
+        . The Agent Pack policy binds posting rights to verifiable credentials,
+        so a personal handle can stay personal, and a corporate handle can
+        grant publishing authority to a credential-gated team — only holders
+        of the credentials you approve can draft and publish, and every action
+        is attributable.
       </>
     ),
     deployYourOwn: {

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -121,7 +121,7 @@ const DEMOS: Demo[] = [
         An AI-powered GitHub assistant that uses the{" "}
         <strong className="text-neutral-900 dark:text-white">Model Context Protocol (MCP)</strong>{" "}
         to interact with GitHub on your behalf. Search repositories, browse
-        issues and pull requests, explore code, and manage your projects —
+        issues and pull requests, explore code, and manage your projects,
         all through an encrypted DIDComm chat in Hologram Messaging. To get
         started: first authenticate using the credential you received from
         the Avatar service, then open the contextual menu, select{" "}
@@ -155,7 +155,7 @@ const DEMOS: Demo[] = [
         <strong className="text-neutral-900 dark:text-white">Model Context Protocol (MCP)</strong>{" "}
         to interact with your Wise account. Check balances, view exchange
         rates, list transfers, send money, create invoices, and manage
-        recipients — all through an encrypted DIDComm chat in Hologram
+        recipients, all through an encrypted DIDComm chat in Hologram
         Messaging. To get started: first authenticate using the credential
         you received from the Avatar service, then open the contextual menu,
         select <em>MCP Server Config</em>, and enter your Wise API Token.
@@ -206,7 +206,7 @@ const DEMOS: Demo[] = [
         <br />
         <br />
         Because each instance is tied to a specific X/Twitter account, there
-        is no shared demo — you deploy your own, linked to your own handle.
+        is no shared demo. You deploy your own, linked to your own handle.
         See the documentation to get started.
         <br />
         <br />
@@ -216,7 +216,7 @@ const DEMOS: Demo[] = [
         </strong>
         . The Agent Pack policy binds posting rights to verifiable credentials,
         so a personal handle can stay personal, and a corporate handle can
-        grant publishing authority to a credential-gated team — only holders
+        grant publishing authority to a credential-gated team. Only holders
         of the credentials you approve can draft and publish, and every action
         is attributable.
       </>

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -329,7 +329,11 @@ function DemoCard({
           <img
             src={demo.art.src}
             alt={demo.art.alt}
-            className="relative w-20 h-20 rounded-2xl object-contain bg-white p-3 shadow-xl"
+            // Same 96×96 footprint as photo icons; `bg-white` keeps
+            // dark marks (GitHub) visible on dark gradients; `p-2`
+            // gives 80px of logo inside a 96px box, so the rendered
+            // mass matches the photo cards visually.
+            className="relative w-24 h-24 rounded-2xl object-contain bg-white p-2 shadow-xl ring-1 ring-white/30"
             loading="lazy"
           />
         )}

--- a/src/components/DemoGrid.tsx
+++ b/src/components/DemoGrid.tsx
@@ -46,7 +46,7 @@ const DEMOS: Demo[] = [
     title: "Avatar",
     tagline: "Your Digital Identity",
     badge: {
-      label: "Human Credential Issuer",
+      label: "Credential Issuer",
       className:
         "bg-brand-500/15 text-brand-700 dark:text-brand-300 ring-1 ring-brand-500/30",
     },
@@ -62,7 +62,7 @@ const DEMOS: Demo[] = [
         A <strong className="text-neutral-900 dark:text-white">DIDComm chatbot</strong>{" "}
         that issues verifiable credentials to users through conversational
         interactions. Connect with Hologram Messaging, follow the guided
-        flow, and receive a W3C Verifiable Credential backed by the Verana
+        flow, and receive a Verifiable Credential backed by the Verana
         Trust Registry. Your credential proves attributes about you and can
         be verified by any party.
       </>
@@ -75,7 +75,7 @@ const DEMOS: Demo[] = [
     title: "Passport",
     tagline: "Government Digital ID",
     badge: {
-      label: "Human Credential Issuer",
+      label: "Credential Issuer",
       className:
         "bg-brand-500/15 text-brand-700 dark:text-brand-300 ring-1 ring-brand-500/30",
     },
@@ -93,7 +93,7 @@ const DEMOS: Demo[] = [
         from government-issued identity documents (passports, ID cards) and
         verifies the holder&apos;s identity via a liveness check with video
         call and gesture detection. Once verified, it issues a passport
-        credential as a W3C Verifiable Credential backed by the Verana Trust
+        credential as a Verifiable Credential backed by the Verana Trust
         Registry.
       </>
     ),


### PR DESCRIPTION
Rewrites the `/demos` page around the actual Verifiable Services that live in `hologram-verifiable-services`. Demo cards now display real service icons, link to the actual repo, use the same descriptions as the playground at [vs.hologram.zone](https://vs.hologram.zone/), and expose a device-aware **Try It** flow: inline QR on tablets/desktops, deep-link redirect on phones.

## What changed

### Page structure

- `src/app/demos/page.tsx` stays a **server** component (keeps `metadata` export working).
- All interactive card logic (QR toggling, phone detection) moves into a new **client** component `src/components/DemoGrid.tsx`.
- A new prerequisite notice block sits directly above the grid, linking to `/apps` for Hologram Messaging install.

### Demo data now matches the playground

Data pulled from `@/Users/mj/git/github/2060-io/hologram-verifiable-services/playground/app/page.tsx` and adapted:

| Demo | Icon | Endpoint | Badge |
|---|---|---|---|
| Avatar | `https://2060.io/images/avatar.jpg` | `avatar.vs.hologram.zone` | **Human Credential Issuer** |
| Passport | `/images/passport.jpg` | `passport.vs.hologram.zone` | **Human Credential Issuer** |
| GitHub Agent | `/images/github.svg` | `github-agent.vs.hologram.zone` | **Community Service** |
| Wise Agent | `/images/wise.svg` | `wise-agent.vs.hologram.zone` | **Community Service** |
| X (Twitter) Agent | *(kept existing stylized X icon, not in playground)* | — | **Personal or Corporate Service** |

- Old badges (`verified`, `NFC + liveness`, `MCP-powered`, `financial`, `creative`) **removed**.
- Old subtitle "Government Digital ID" folded into the Passport card tagline.
- `GitHub ↗` link on Avatar/Passport/GitHub/Wise now points at `github.com/2060-io/hologram-verifiable-services` (the actual monorepo for these services). X Agent links to `github.com/2060-io/x-autonomous-mcp`.

### Phone vs tablet/desktop routing

The spec: phones redirect to `${endpoint}/invitation` (which triggers the Hologram Messaging deep-link); tablets and desktops show an inline QR that you scan with your phone.

Detection is UA-based via a tight regex:

```@/Users/mj/git/github/2060-io/hologram.zone-website/src/components/DemoGrid.tsx:217-220
const PHONE_UA_RE =
  /(iPhone|iPod|Android.*Mobile|IEMobile|BlackBerry|Opera Mini)/i;
```

Deliberate choices:

- **iPad on iPadOS 13+** reports as "Macintosh" → does not match → **QR**. ✅ (iPad is "tablet" per the spec.)
- **Android tablets** have "Android" but **no** `Mobile` token → does not match → **QR**. ✅
- **Android phones** have `Android … Mobile` → matches → redirect. ✅
- **iPhone / iPod / BlackBerry / IEMobile / Opera Mini** → redirect. ✅

### Single-QR-at-a-time

The `openQrId` state lives in `<DemoGrid>` (one level above each card). Opening a QR for Avatar while Passport's QR is open closes Passport's first, then opens Avatar's — "only one QR can be shown at the same time", as requested.

Button label toggles between **Try It** and **Hide QR** for the same card.

QR source is `${endpoint}/qr`, matching the playground at `@/Users/mj/git/github/2060-io/hologram-verifiable-services/playground/app/page.tsx:176`.

### X (Twitter) Agent

- No endpoint → no QR, no "Try It".
- Primary CTA becomes **Deploy Your Own ↗** → `https://docs.hologram.zone`.
- Description gains a second paragraph explaining why: each instance is tied to a specific X/Twitter account, so there's no shared demo.
- Icon + stylized header preserved (not in the playground).

### Prerequisite notice above the grid

```@/Users/mj/git/github/2060-io/hologram.zone-website/src/app/demos/page.tsx:42-75
<div className="rounded-2xl border border-brand-500/25 bg-brand-500/5 ...">
  ...
  <p className="font-semibold ...">You'll need the Hologram app to try these demos.</p>
  <p className="mt-1">
    Every demo connects over DIDComm with <strong>Hologram Messaging</strong> on
    your phone. If you don't have it yet, grab it from the <Link href="/apps">Apps page</Link>
    — it's free on iOS and Android.
  </p>
</div>
```

## Verification

- `npm run build` — passes; `/demos` is 3.3 kB + 109 kB first-load JS
- Manually clicking **Try It** on a desktop UA opens Avatar's QR; clicking Passport's button swaps the open QR to Passport; clicking Passport again closes it
- On a phone UA (or DevTools device emulation with an iPhone), **Try It** navigates to `${endpoint}/invitation` directly

## Open items I assumed — please flag if wrong

- **X Agent GitHub link** — you didn't specify where it should point, so I used `github.com/2060-io/x-autonomous-mcp`. Happy to change.
- **Passport card title** — you called it "Passport" (playground calls it "Passport Issuer"); I used **Passport** as the heading and kept "Government Digital ID" as the tagline.
- **Avatar icon** — served externally from `2060.io`. If you want it hosted locally, drop the file at `public/images/avatar.jpg` and I'll switch the URL.