### PR TITLE
feat: post contact form to Relaticle CRM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env.local for local development (.env* is gitignored).
+# In production these come from the chart (RELATICLE_API_URL) and the k8s
+# `website-secrets` Secret, which the deploy workflows populate from the
+# RELATICLE_API_TOKEN GitHub Actions secret — do NOT ship a .env file.
+
+# Relaticle CRM — the /contact form posts inquiries here.
+# Locally you can point at the public instance; in-cluster the deployment uses
+# http://relaticle.relaticle.svc.cluster.local
+RELATICLE_API_URL=https://crm.2060.io
+RELATICLE_API_TOKEN=
+
+# Optional: Discord/Slack-compatible webhook for best-effort ops alerts when a
+# CRM write fails. Leave empty to log to stderr only.
+ALERT_WEBHOOK_URL=

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,6 +136,19 @@ jobs:
           chmod 600 "$HOME/.kube/config"
           kubectl cluster-info
 
+      - name: Create/refresh app secret
+        # Token consumed by the /contact route (Relaticle CRM). Created via
+        # kubectl (not helm) and annotated keep so helm never prunes it.
+        env:
+          RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
+        run: |
+          kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n web create secret generic website-secrets \
+            --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n web annotate secret website-secrets \
+            helm.sh/resource-policy=keep --overwrite
+
       - name: Helm upgrade
         run: |
           echo "Deploying io2060/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }} to namespace 'web'..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,19 @@ jobs:
           echo "::error::Image $IMAGE was not available after ~5 minutes."
           exit 1
 
+      - name: Create/refresh app secret
+        # Token consumed by the /contact route (Relaticle CRM). Created via
+        # kubectl (not helm) and annotated keep so helm never prunes it.
+        env:
+          RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
+        run: |
+          kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n web create secret generic website-secrets \
+            --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n web annotate secret website-secrets \
+            helm.sh/resource-policy=keep --overwrite
+
       - name: Helm upgrade
         run: |
           helm upgrade --install hologram-website ./charts \

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -42,6 +42,19 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+            {{- if .Values.relaticle.enabled }}
+            # Relaticle CRM (in-cluster). The contact form posts inquiries here.
+            - name: RELATICLE_API_URL
+              value: {{ .Values.relaticle.apiUrl | quote }}
+            - name: RELATICLE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.relaticle.secretName }}
+                  key: RELATICLE_API_TOKEN
+                  # Optional so the pod still starts if the secret is absent;
+                  # the contact route degrades to best-effort (logs only).
+                  optional: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -66,6 +66,15 @@ probes:
     timeoutSeconds: 3
     failureThreshold: 3
 
+# Relaticle CRM integration for the /contact form. The token is injected into
+# the `secretName` Secret by the deploy workflows from the RELATICLE_API_TOKEN
+# GitHub Actions secret (kubectl create secret, kept across helm upgrades).
+relaticle:
+  enabled: true
+  # In-cluster Relaticle service (same OVH cluster, namespace `relaticle`).
+  apiUrl: http://relaticle.relaticle.svc.cluster.local
+  secretName: website-secrets
+
 podSecurityContext: {}
 securityContext: {}
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  submitInquiry,
+  crmConfigured,
+  alertOps,
+  type Inquiry,
+} from "@/lib/relaticle";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MIN_MESSAGE = 50;
+const MAX_MESSAGE = 4000;
+
+// Naive in-memory rate limit. The deployment runs a single replica, so a
+// per-process map is sufficient as a best-effort guard (in addition to the
+// CRM's own throttle:api).
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 5;
+const hits = new Map<string, number[]>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const recent = (hits.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+  recent.push(now);
+  hits.set(ip, recent);
+  return recent.length > RATE_MAX;
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+export async function POST(req: NextRequest) {
+  let data: Record<string, unknown>;
+  try {
+    data = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "bad_request" }, { status: 400 });
+  }
+
+  // Honeypot: a filled hidden field means a bot. Pretend success, do nothing.
+  if (typeof data.website_hp === "string" && data.website_hp.trim() !== "") {
+    return NextResponse.json({ ok: true });
+  }
+
+  // Time-to-submit: human submissions take more than a couple of seconds.
+  const renderedAt = Number(data.rendered_at);
+  if (Number.isFinite(renderedAt) && Date.now() - renderedAt < 2500) {
+    return NextResponse.json({ ok: true });
+  }
+
+  const topic = String(data.topic ?? "").trim();
+  const name = String(data.name ?? "").trim();
+  const email = String(data.email ?? "").trim();
+  const message = String(data.message ?? "").trim();
+  const consent =
+    data.consent === true || data.consent === "on" || data.consent === "true";
+
+  const fields: string[] = [];
+  if (!topic) fields.push("topic");
+  if (!name) fields.push("name");
+  if (!EMAIL_RE.test(email)) fields.push("email");
+  if (message.length < MIN_MESSAGE || message.length > MAX_MESSAGE)
+    fields.push("message");
+  if (!consent) fields.push("consent");
+  if (fields.length > 0) {
+    return NextResponse.json(
+      { ok: false, error: "validation", fields },
+      { status: 422 }
+    );
+  }
+
+  const ip =
+    (req.headers.get("x-forwarded-for") ?? "").split(",")[0].trim() || "unknown";
+  if (rateLimited(ip)) {
+    return NextResponse.json({ ok: false, error: "rate_limited" }, { status: 429 });
+  }
+
+  const inquiry: Inquiry = {
+    topic,
+    name,
+    email,
+    organization: String(data.organization ?? "").trim() || undefined,
+    role: String(data.role ?? "").trim() || undefined,
+    linkedin: String(data.linkedin ?? "").trim() || undefined,
+    companyWebsite: String(data.company_website ?? "").trim() || undefined,
+    message,
+    source: String(data.source ?? "").trim() || undefined,
+    consentAt: new Date().toISOString(),
+  };
+
+  // If the CRM isn't configured (e.g. local dev without a token), don't fail
+  // the user — log and report success.
+  if (!crmConfigured()) {
+    console.warn(
+      "[contact] Relaticle not configured; inquiry not sent to CRM:",
+      { topic, name, email, organization: inquiry.organization }
+    );
+    return NextResponse.json({ ok: true });
+  }
+
+  try {
+    const ids = await submitInquiry(inquiry);
+    console.info("[contact] CRM records created", ids);
+  } catch (err) {
+    console.error("[contact] CRM submission failed", err, {
+      topic,
+      name,
+      email,
+      organization: inquiry.organization,
+    });
+    await alertOps(
+      `Contact form (hologram.zone): CRM write failed for ${name} <${email}> (${topic}). ${String(
+        err
+      ).slice(0, 300)}`
+    );
+    // Surface the failure so the user sees an error and can resubmit.
+    return NextResponse.json({ ok: false, error: "crm" }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -137,7 +137,7 @@ export default function ContactPage() {
               </li>
               <li className="flex items-start gap-3">
                 <IconDatabase className="w-5 h-5 shrink-0 mt-0.5 text-neutral-500" aria-hidden="true" />
-                <span>One processor: OVHcloud Canada (Beauharnois, Québec). No CDN. Covered by EC adequacy decision 2002/2/EC.</span>
+                <span>Inquiries are stored in our self-hosted Relaticle CRM (crm.2060.io) so we can follow up. No third-party CRM.</span>
               </li>
               <li className="flex items-start gap-3">
                 <IconCookie className="w-5 h-5 shrink-0 mt-0.5 text-neutral-500" aria-hidden="true" />

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /* -------------------------------------------------------------------------- */
 /*  ContactForm                                                               */
 /*                                                                            */
-/*  Client-side form UI for /contact.                                         */
+/*  Client-side form for /contact. Posts to /api/contact, which writes the    */
+/*  inquiry into the self-hosted Relaticle CRM (best-effort on the server).   */
 /*                                                                            */
-/*  NOTE — submission is currently stubbed: on submit we prevent-default and  */
-/*  show a success card. When the backend intake endpoint is ready, replace   */
-/*  the TODO in `handleSubmit` with a POST to that endpoint and branch on     */
-/*  the response.                                                             */
-/*                                                                            */
-/*  Anti-spam built in at the UI level:                                       */
-/*    - honeypot field "website" hidden off-screen                            */
-/*    - min-length requirement on the message                                 */
-/*    - explicit consent checkbox                                             */
+/*  Anti-spam at the UI level: honeypot field "website_hp" hidden off-screen, */
+/*  a render timestamp for a server-side time-to-submit check, a min-length   */
+/*  message, and an explicit consent checkbox.                                */
 /* -------------------------------------------------------------------------- */
 
 const FIELD =
@@ -23,56 +18,150 @@ const FIELD =
 const LABEL =
   "block text-sm font-medium text-neutral-900 dark:text-white mb-2";
 
+const MIN_MESSAGE = 50;
+const MAX_MESSAGE = 4000;
+
+const TOPICS = [
+  { value: "enterprise", label: "Enterprise or consortium: Hologram deployment, trust-registry engagement" },
+  { value: "investor", label: "Investor: equity round, investor memo, data-room access" },
+  { value: "press", label: "Press or analyst" },
+  { value: "hiring", label: "Hiring: send work, not résumés" },
+  { value: "general", label: "General inquiry" },
+];
+
+const VALIDATION_MSG = `Please complete the required fields — a valid email and a message of at least ${MIN_MESSAGE} characters — then try again.`;
+const SUBMIT_MSG =
+  "Sorry, we couldn't send your message just now. Please try again in a moment, or reach a founder on LinkedIn.";
+
 export default function ContactForm() {
-  const [state, setState] = useState<"idle" | "submitted" | "error">("idle");
+  const [state, setState] = useState<"idle" | "submitting" | "submitted" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
   const [charCount, setCharCount] = useState(0);
+  const [renderedAt, setRenderedAt] = useState("");
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setRenderedAt(String(Date.now()));
+  }, []);
+
+  // Make the outcome visible (especially on mobile) by scrolling the banner
+  // into view on success/error.
+  useEffect(() => {
+    if (state === "submitted" || state === "error") {
+      bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [state]);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    const form = e.currentTarget;
 
-    // Honeypot — if the hidden "website" field is filled, silently
-    // drop the submission (bots fill every input they see).
-    const form = new FormData(e.currentTarget);
-    if (form.get("website")) {
+    const honeypot = (form.elements.namedItem("website_hp") as HTMLInputElement)
+      ?.value;
+    if (honeypot) {
       setState("submitted");
       return;
     }
 
-    // TODO: wire to the backend intake endpoint when it is available.
-    //       For now we just acknowledge the submission locally so the
-    //       UI behaves like a real form.
-    setState("submitted");
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      setErrorMsg(VALIDATION_MSG);
+      setState("error");
+      return;
+    }
+
+    const fd = new FormData(form);
+    const payload = {
+      topic: fd.get("topic"),
+      name: fd.get("name"),
+      email: fd.get("email"),
+      organization: fd.get("organization"),
+      role: fd.get("role"),
+      linkedin: fd.get("linkedin"),
+      company_website: fd.get("company_website"),
+      message: fd.get("message"),
+      source: fd.get("source"),
+      consent: (form.elements.namedItem("consent") as HTMLInputElement)?.checked,
+      website_hp: honeypot ?? "",
+      rendered_at: renderedAt,
+    };
+
+    setState("submitting");
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setState("submitted");
+      form.reset();
+      setCharCount(0);
+    } catch {
+      setErrorMsg(SUBMIT_MSG);
+      setState("error");
+    }
   }
 
+  // Success — replace the form with a confirmation card.
   if (state === "submitted") {
     return (
       <div
-        className="mt-8 card rounded-2xl p-6"
+        ref={bannerRef}
+        className="mt-8 card rounded-2xl p-6 border-l-4"
+        style={{ borderLeftColor: "#1FB57A" }}
         role="status"
         aria-live="polite"
       >
-        <h3 className="font-display text-lg font-bold">Thank you.</h3>
+        <h3 className="font-display text-lg font-bold flex items-center gap-2">
+          <span aria-hidden="true" style={{ color: "#1FB57A" }}>
+            ✓
+          </span>
+          Message sent
+        </h3>
         <p className="mt-2 text-sm text-neutral-500">
-          We received your inquiry and will reply within one business day. For
-          urgent matters, reach a founder on LinkedIn.
+          Thank you — we received your inquiry and will reply within one business
+          day. For urgent matters, reach a founder on LinkedIn.
         </p>
+        <button
+          type="button"
+          onClick={() => setState("idle")}
+          className="mt-4 px-5 py-2.5 rounded-xl text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white shadow-lg shadow-brand-600/30 transition"
+        >
+          Send another message
+        </button>
       </div>
     );
   }
 
-  if (state === "error") {
-    return (
-      <div className="mt-8 card rounded-2xl p-6" role="alert">
-        <h3 className="font-display text-lg font-bold">Something went wrong.</h3>
-        <p className="mt-2 text-sm text-neutral-500">
-          Please try again, or reach a founder on LinkedIn directly.
-        </p>
-      </div>
-    );
-  }
+  const submitting = state === "submitting";
+  const errored = state === "error";
 
   return (
     <form onSubmit={handleSubmit} className="mt-8 space-y-5" noValidate>
+      {/* Error banner — keeps the form so it can be re-submitted. */}
+      {errored && (
+        <div
+          ref={bannerRef}
+          role="alert"
+          aria-live="assertive"
+          className="card rounded-2xl p-5 border-l-4"
+          style={{ borderLeftColor: "#e5484d", background: "rgba(229,72,77,0.08)" }}
+        >
+          <h3 className="font-display text-lg font-bold" style={{ color: "#e5484d" }}>
+            Couldn&rsquo;t send your message
+          </h3>
+          <p className="mt-2 text-sm text-neutral-500">{errorMsg}</p>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="mt-4 px-5 py-2.5 rounded-xl text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white shadow-lg shadow-brand-600/30 transition disabled:opacity-60"
+          >
+            {submitting ? "Sending…" : "Try again"}
+          </button>
+        </div>
+      )}
+
       {/* Honeypot — hidden from humans, a giveaway for bots. */}
       <div
         aria-hidden="true"
@@ -87,9 +176,10 @@ export default function ContactForm() {
       >
         <label>
           Leave this field empty:
-          <input name="website" tabIndex={-1} autoComplete="off" />
+          <input name="website_hp" tabIndex={-1} autoComplete="off" />
         </label>
       </div>
+      <input type="hidden" name="rendered_at" value={renderedAt} readOnly />
 
       <div>
         <label htmlFor="topic" className={LABEL}>
@@ -102,15 +192,11 @@ export default function ContactForm() {
           <option value="" disabled>
             Select one
           </option>
-          <option value="enterprise">
-            Enterprise or consortium: Hologram deployment, trust-registry engagement
-          </option>
-          <option value="investor">
-            Investor: equity round, investor memo, data-room access
-          </option>
-          <option value="press">Press or analyst</option>
-          <option value="hiring">Hiring: send work, not résumés</option>
-          <option value="general">General inquiry</option>
+          {TOPICS.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
         </select>
       </div>
 
@@ -147,6 +233,24 @@ export default function ContactForm() {
             className={FIELD}
           />
         </div>
+      </div>
+
+      <div>
+        <label htmlFor="linkedin" className={LABEL}>
+          Your LinkedIn{" "}
+          <span className="text-neutral-500 text-xs font-normal">(optional)</span>
+        </label>
+        <input
+          id="linkedin"
+          name="linkedin"
+          type="url"
+          autoComplete="url"
+          placeholder="https://www.linkedin.com/in/…"
+          className={FIELD}
+        />
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-5">
         <div>
           <label htmlFor="organization" className={LABEL}>
             Organization{" "}
@@ -178,21 +282,20 @@ export default function ContactForm() {
             className={FIELD}
           />
         </div>
-        <div className="md:col-span-2">
-          <label htmlFor="linkedin" className={LABEL}>
-            LinkedIn or website{" "}
-            <span className="text-neutral-500 text-xs font-normal">
-              (optional)
-            </span>
-          </label>
-          <input
-            id="linkedin"
-            name="linkedin"
-            type="url"
-            placeholder="https://…"
-            className={FIELD}
-          />
-        </div>
+      </div>
+
+      <div>
+        <label htmlFor="company_website" className={LABEL}>
+          Company Website{" "}
+          <span className="text-neutral-500 text-xs font-normal">(optional)</span>
+        </label>
+        <input
+          id="company_website"
+          name="company_website"
+          type="url"
+          placeholder="https://…"
+          className={FIELD}
+        />
       </div>
 
       <div>
@@ -207,23 +310,21 @@ export default function ContactForm() {
           name="message"
           rows={6}
           required
-          minLength={50}
-          maxLength={4000}
+          minLength={MIN_MESSAGE}
+          maxLength={MAX_MESSAGE}
           onChange={(e) => setCharCount(e.target.value.length)}
           placeholder="What are you building or evaluating, what is the question, and what timeline are you on?"
           className={FIELD}
         />
         <p className="text-xs text-neutral-500 mt-2">
-          {charCount} / 4000 (min 50)
+          {charCount} / {MAX_MESSAGE} (min {MIN_MESSAGE})
         </p>
       </div>
 
       <div>
         <label htmlFor="source" className={LABEL}>
           How did you hear about us{" "}
-          <span className="text-neutral-500 text-xs font-normal">
-            (optional)
-          </span>
+          <span className="text-neutral-500 text-xs font-normal">(optional)</span>
         </label>
         <select id="source" name="source" className={FIELD} defaultValue="">
           <option value="">(none)</option>
@@ -262,9 +363,10 @@ export default function ContactForm() {
       <div className="pt-4 flex flex-wrap items-center gap-4">
         <button
           type="submit"
-          className="px-5 py-2.5 rounded-xl text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white shadow-lg shadow-brand-600/30 transition"
+          disabled={submitting}
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold bg-brand-600 hover:bg-brand-500 text-white shadow-lg shadow-brand-600/30 transition disabled:opacity-60"
         >
-          Send message
+          {submitting ? "Sending…" : "Send message"}
         </button>
         <span className="text-xs text-neutral-500">
           We reply within one business day. For urgent matters, reach a founder

--- a/src/lib/relaticle.ts
+++ b/src/lib/relaticle.ts
@@ -1,0 +1,410 @@
+/**
+ * Server-only client for the Relaticle CRM REST API (https://crm.2060.io,
+ * in-cluster). Turns a contact-form submission into CRM records.
+ *
+ * Mapping (mirrors the 2060.io / Verana Foundation sites):
+ *   organization   -> Company    (always created when present; no dedupe)
+ *   name/email/…   -> Person      (linked to the company)
+ *   full inquiry   -> Note        (linked to the person + company)
+ *   lead inquiries -> Opportunity (investor / enterprise; stage = Prospecting)
+ *   every inquiry  -> Task        ("To do", Low priority, due in 3 days,
+ *                                   assigned to the connected account)
+ *
+ * Records are created by the API token's user — a "hologram.zone" service
+ * account on the 2060 team — so the CRM shows them as created by hologram.zone.
+ *
+ * Relaticle API contract (v1):
+ *   POST /api/v1/people        { name, company_id?, custom_fields:{<code>:value} }
+ *   POST /api/v1/companies     { name, custom_fields }
+ *   POST /api/v1/notes         { title, people_ids?[], company_ids?[], custom_fields }
+ *   POST /api/v1/opportunities { name, company_id?, contact_id?, custom_fields }
+ *   POST /api/v1/tasks         { title, assignee_ids?[], people_ids?[], company_ids?[],
+ *                                opportunity_ids?[], custom_fields }
+ *   GET  /api/v1/custom-fields?entity_type=…  (JSON:API: data[].attributes.{code,name,type,options})
+ *   GET  /api/v1/user          (connected account; data.id)
+ *   Auth: Authorization: Bearer <token>.
+ *
+ * `custom_fields` is keyed by each field's *code*. Field codes/types/options are
+ * discovered at runtime. Value shape depends on the field type: email/phone/link
+ * fields take an ARRAY of values; text/rich-editor/select take a scalar (select
+ * = the chosen option's value/id). Each create falls back to a
+ * custom-field-free payload if the CRM rejects the custom fields, so a mapping
+ * mismatch never loses the core record.
+ *
+ * Never import this from a client component.
+ */
+
+const BASE = process.env.RELATICLE_API_URL?.replace(/\/+$/, "");
+const TOKEN = process.env.RELATICLE_API_TOKEN;
+const ALERT_WEBHOOK = process.env.ALERT_WEBHOOK_URL;
+
+export function crmConfigured(): boolean {
+  return Boolean(BASE && TOKEN);
+}
+
+export type Inquiry = {
+  topic: string;
+  name: string;
+  email: string;
+  organization?: string;
+  role?: string;
+  linkedin?: string; // the person's LinkedIn
+  companyWebsite?: string; // the company's website (or LinkedIn if a linkedin.com URL)
+  message: string;
+  source?: string;
+  consentAt: string;
+};
+
+export type CrmResult = {
+  personId?: string;
+  companyId?: string;
+  noteId?: string;
+  opportunityId?: string;
+  taskId?: string;
+};
+
+const TOPIC_LABELS: Record<string, string> = {
+  enterprise: "Enterprise / consortium",
+  investor: "Investor",
+  press: "Press or analyst",
+  hiring: "Hiring",
+  general: "General inquiry",
+};
+
+// Inquiry types that should also open an Opportunity (a lead in the pipeline).
+const LEAD_TOPICS = new Set(["investor", "enterprise"]);
+
+// Custom-field types whose value must be sent as an array (verified against the
+// live API: email/phone/link reject scalars; text/select/rich-editor are scalar).
+const ARRAY_TYPES = new Set([
+  "email",
+  "phone",
+  "link",
+  "url",
+  "tags",
+  "multi_select",
+  "multiselect",
+  "checkbox-list",
+]);
+
+function topicLabel(topic: string): string {
+  return TOPIC_LABELS[topic] ?? topic ?? "Inquiry";
+}
+
+// --- low-level HTTP ---------------------------------------------------------
+
+type AnyJson = Record<string, unknown>;
+
+async function api(
+  path: string,
+  init: { method: string; body?: AnyJson }
+): Promise<unknown> {
+  const res = await fetch(`${BASE}/api/v1${path}`, {
+    method: init.method,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: init.body ? JSON.stringify(init.body) : undefined,
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `Relaticle ${init.method} ${path} -> ${res.status} ${text.slice(0, 400)}`
+    );
+  }
+  if (res.status === 204) return null;
+  return res.json().catch(() => null);
+}
+
+function idOf(resp: unknown): string | undefined {
+  const r = resp as { data?: { id?: string }; id?: string } | null;
+  return r?.data?.id ?? r?.id;
+}
+
+// --- custom-field discovery (cached) ---------------------------------------
+
+type FieldOption = { label: string; value: string };
+type CustomField = {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  options: FieldOption[];
+};
+const cfCache = new Map<string, { at: number; fields: CustomField[] }>();
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+async function customFields(entityType: string): Promise<CustomField[]> {
+  const cached = cfCache.get(entityType);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.fields;
+
+  const fields: CustomField[] = [];
+  for (let page = 1; page <= 10; page++) {
+    const data = (await api(
+      `/custom-fields?entity_type=${encodeURIComponent(entityType)}&page=${page}`,
+      { method: "GET" }
+    )) as
+      | { data?: Array<Record<string, unknown>>; links?: { next?: string | null } }
+      | Array<Record<string, unknown>>;
+    const items = Array.isArray(data) ? data : (data?.data ?? []);
+    for (const it of items) {
+      // JSON:API shape: { id, attributes:{ code, name, type, options } }
+      const a = (it.attributes ?? it) as Record<string, unknown>;
+      if (a.code) {
+        fields.push({
+          id: String(it.id ?? a.id ?? ""),
+          code: String(a.code),
+          name: String(a.name ?? ""),
+          type: String(a.type ?? ""),
+          options: Array.isArray(a.options)
+            ? (a.options as FieldOption[]).map((o) => ({
+                label: String(o.label),
+                value: String(o.value),
+              }))
+            : [],
+        });
+      }
+    }
+    const next = Array.isArray(data) ? null : data?.links?.next;
+    if (!next || items.length === 0) break;
+  }
+
+  cfCache.set(entityType, { at: Date.now(), fields });
+  return fields;
+}
+
+/** The connected account (token owner), used to assign tasks. Cached. */
+let userCache: { at: number; id?: string } | null = null;
+async function connectedUserId(): Promise<string | undefined> {
+  if (userCache && Date.now() - userCache.at < CACHE_TTL_MS) return userCache.id;
+  try {
+    const id = idOf(await api("/user", { method: "GET" }));
+    userCache = { at: Date.now(), id };
+    return id;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Find a field by candidate codes (preferred), then a name/code regex fallback. */
+function findField(
+  fields: CustomField[],
+  codes: string[],
+  nameRe?: RegExp
+): CustomField | undefined {
+  const byCode = fields.find((f) =>
+    codes.some((c) => c.toLowerCase() === f.code.toLowerCase())
+  );
+  if (byCode) return byCode;
+  return nameRe
+    ? fields.find((f) => nameRe.test(f.code) || nameRe.test(f.name))
+    : undefined;
+}
+
+/** The value (option id) of a select field's option whose label matches. */
+function optionValue(
+  field: CustomField | undefined,
+  labelRe: RegExp
+): string | undefined {
+  return field?.options.find((o) => labelRe.test(o.label))?.value;
+}
+
+/** Add `value` to `target` under the field's code, shaped per the field type. */
+function addCustom(
+  target: AnyJson,
+  field: CustomField | undefined,
+  value: string | undefined
+): void {
+  if (!field || !value) return;
+  target[field.code] = ARRAY_TYPES.has(field.type.toLowerCase())
+    ? [value]
+    : value;
+}
+
+/** POST with custom fields, retrying without them if the CRM rejects them. */
+async function createWithFallback(
+  path: string,
+  base: AnyJson,
+  custom: AnyJson
+): Promise<unknown> {
+  try {
+    return await api(path, { method: "POST", body: { ...base, custom_fields: custom } });
+  } catch (err) {
+    if (Object.keys(custom).length === 0) throw err;
+    console.warn(
+      `[relaticle] ${path} create with custom_fields failed, retrying without them:`,
+      String(err).slice(0, 300)
+    );
+    return api(path, { method: "POST", body: { ...base, custom_fields: {} } });
+  }
+}
+
+// --- content helpers --------------------------------------------------------
+
+function noteTitle(inq: Inquiry): string {
+  const org = inq.organization ? ` (${inq.organization})` : "";
+  return `${topicLabel(inq.topic)} — ${inq.name}${org}`.slice(0, 255);
+}
+
+function noteBody(inq: Inquiry): string {
+  const lines = [
+    `Inquiry type: ${topicLabel(inq.topic)}`,
+    `Name: ${inq.name}`,
+    `Email: ${inq.email}`,
+    inq.linkedin ? `LinkedIn: ${inq.linkedin}` : null,
+    inq.organization ? `Organization: ${inq.organization}` : null,
+    inq.companyWebsite ? `Company website: ${inq.companyWebsite}` : null,
+    inq.role ? `Role: ${inq.role}` : null,
+    inq.source ? `Heard about us: ${inq.source}` : null,
+    `Consent: yes (${inq.consentAt})`,
+    "",
+    "Message:",
+    inq.message,
+  ];
+  return lines.filter((l) => l !== null).join("\n");
+}
+
+// --- orchestration ----------------------------------------------------------
+
+export async function submitInquiry(inq: Inquiry): Promise<CrmResult> {
+  const result: CrmResult = {};
+
+  // 1) Company (always create when an organization is given; no dedupe). The
+  // "company website" goes to the company LinkedIn field for linkedin.com URLs,
+  // otherwise to the company domains/website field.
+  if (inq.organization?.trim()) {
+    const cf = await customFields("company");
+    const fields: AnyJson = {};
+    const w = inq.companyWebsite?.trim();
+    if (w) {
+      const field = /linkedin\.com/i.test(w)
+        ? findField(cf, ["linkedin"], /linkedin/i)
+        : findField(cf, ["domains", "domain", "website", "url"], /domain|website|url|link/i);
+      addCustom(fields, field, w);
+    }
+    const company = await createWithFallback(
+      "/companies",
+      { name: inq.organization.trim() },
+      fields
+    );
+    result.companyId = idOf(company);
+  }
+
+  // 2) Person (linked to the company): email, job title, the person's LinkedIn.
+  {
+    const cf = await customFields("people");
+    const fields: AnyJson = {};
+    addCustom(fields, findField(cf, ["emails", "email"], /email/i), inq.email);
+    addCustom(
+      fields,
+      findField(cf, ["job_title"], /job.?title|role|position|title/i),
+      inq.role
+    );
+    addCustom(
+      fields,
+      findField(cf, ["linkedin", "links", "url"], /linkedin|link|url/i),
+      inq.linkedin
+    );
+    const person = await createWithFallback(
+      "/people",
+      { name: inq.name, company_id: result.companyId ?? null },
+      fields
+    );
+    result.personId = idOf(person);
+  }
+
+  // 3) Note carrying the full inquiry, linked to the person + company.
+  {
+    const cf = await customFields("note");
+    const fields: AnyJson = {};
+    addCustom(
+      fields,
+      findField(
+        cf,
+        ["body", "content", "description", "note"],
+        /body|content|description|note|message|text/i
+      ),
+      noteBody(inq)
+    );
+    const note = await createWithFallback(
+      "/notes",
+      {
+        title: noteTitle(inq),
+        people_ids: result.personId ? [result.personId] : [],
+        company_ids: result.companyId ? [result.companyId] : [],
+      },
+      fields
+    );
+    result.noteId = idOf(note);
+  }
+
+  // 4) Opportunity for lead-type inquiries, stage = Prospecting.
+  if (LEAD_TOPICS.has(inq.topic)) {
+    const cf = await customFields("opportunity");
+    const fields: AnyJson = {};
+    const stage = findField(cf, ["stage"], /stage/i);
+    const prospecting = optionValue(stage, /prospect/i);
+    if (stage && prospecting) fields[stage.code] = prospecting;
+    const opp = await createWithFallback(
+      "/opportunities",
+      {
+        name: noteTitle(inq),
+        company_id: result.companyId ?? null,
+        contact_id: result.personId ?? null,
+      },
+      fields
+    );
+    result.opportunityId = idOf(opp);
+  }
+
+  // 5) Follow-up Task (every inquiry): status "To do", Low priority, due in
+  // 3 days, assigned to the connected account, linked to the records above.
+  {
+    const cf = await customFields("task");
+    const fields: AnyJson = {};
+    const status = findField(cf, ["status"], /status/i);
+    const todo = optionValue(status, /^to.?do$|todo/i);
+    if (status && todo) fields[status.code] = todo;
+    const priority = findField(cf, ["priority"], /priority/i);
+    const low = optionValue(priority, /^low$/i);
+    if (priority && low) fields[priority.code] = low;
+    const dueField = findField(cf, ["due_date", "due"], /due/i);
+    if (dueField) {
+      const due = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+      fields[dueField.code] = due.toISOString().replace(/\.\d{3}Z$/, "Z");
+    }
+    const userId = await connectedUserId();
+    const task = await createWithFallback(
+      "/tasks",
+      {
+        title: `Follow up: ${noteTitle(inq)}`.slice(0, 255),
+        assignee_ids: userId ? [userId] : [],
+        people_ids: result.personId ? [result.personId] : [],
+        company_ids: result.companyId ? [result.companyId] : [],
+        opportunity_ids: result.opportunityId ? [result.opportunityId] : [],
+      },
+      fields
+    );
+    result.taskId = idOf(task);
+  }
+
+  return result;
+}
+
+/** Best-effort ops alert (Discord/Slack-compatible webhook). No-op if unset. */
+export async function alertOps(message: string): Promise<void> {
+  if (!ALERT_WEBHOOK) return;
+  try {
+    await fetch(ALERT_WEBHOOK, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: message }),
+      cache: "no-store",
+    });
+  } catch {
+    /* swallow — alerting must never throw */
+  }
+}


### PR DESCRIPTION
Wire the /contact form to the self-hosted Relaticle CRM (crm.2060.io, in-cluster) so submissions populate the CRM as the "hologram.zone" service account.

- Server-only client (src/lib/relaticle.ts): creates a Company (when an organization is given), a Person (email/job title/LinkedIn), a Note with the full inquiry, an Opportunity (investor/enterprise leads; stage = Prospecting), and a "To do" Task (Low priority, due in 3 days, assigned to the connected account). Custom-field codes/options resolved at runtime; each create falls back to a custom-field-free payload on rejection.
- Route (src/app/api/contact/route.ts): server-side anti-abuse (honeypot, time-to-submit, per-IP rate limit) + validation; returns 502 on CRM failure so the form shows an error and can be resubmitted.
- ContactForm.tsx: wire the previously-stubbed submit to POST /api/contact; add "Your LinkedIn" and "Company Website" fields; prominent success/error banners (mobile-friendly, scroll into view); honeypot renamed website_hp.
- Chart: RELATICLE_API_URL env + RELATICLE_API_TOKEN from website-secrets; deploy workflows upsert the secret from the GitHub Actions secret.
- Contact page: name the self-hosted Relaticle CRM as the processor.