### PR TITLE
feat: hologram-specific inquiry types + site-scoped CRM secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Copy to .env.local for local development (.env* is gitignored).
 # In production these come from the chart (RELATICLE_API_URL) and the k8s
-# `website-secrets` Secret, which the deploy workflows populate from the
+# `hologram-website-secrets` Secret, which the deploy workflows populate from the
 # RELATICLE_API_TOKEN GitHub Actions secret — do NOT ship a .env file.
 
 # Relaticle CRM — the /contact form posts inquiries here.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,10 +143,10 @@ jobs:
           RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
         run: |
           kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web create secret generic website-secrets \
+          kubectl -n web create secret generic hologram-website-secrets \
             --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web annotate secret website-secrets \
+          kubectl -n web annotate secret hologram-website-secrets \
             helm.sh/resource-policy=keep --overwrite
 
       - name: Helm upgrade

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,10 +80,10 @@ jobs:
           RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
         run: |
           kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web create secret generic website-secrets \
+          kubectl -n web create secret generic hologram-website-secrets \
             --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web annotate secret website-secrets \
+          kubectl -n web annotate secret hologram-website-secrets \
             helm.sh/resource-policy=keep --overwrite
 
       - name: Helm upgrade

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -73,7 +73,7 @@ relaticle:
   enabled: true
   # In-cluster Relaticle service (same OVH cluster, namespace `relaticle`).
   apiUrl: http://relaticle.relaticle.svc.cluster.local
-  secretName: website-secrets
+  secretName: hologram-website-secrets
 
 podSecurityContext: {}
 securityContext: {}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -22,10 +22,11 @@ const MIN_MESSAGE = 50;
 const MAX_MESSAGE = 4000;
 
 const TOPICS = [
-  { value: "enterprise", label: "Enterprise or consortium: Hologram deployment, trust-registry engagement" },
-  { value: "investor", label: "Investor: equity round, investor memo, data-room access" },
+  { value: "enterprise", label: "Hologram Cloud: enterprise or on-premise deployment" },
+  { value: "sales", label: "Plans & subscriptions: pricing, quotes, billing" },
+  { value: "partnership", label: "Partnership / integration" },
+  { value: "build", label: "Building an agent: developer support" },
   { value: "press", label: "Press or analyst" },
-  { value: "hiring", label: "Hiring: send work, not résumés" },
   { value: "general", label: "General inquiry" },
 ];
 

--- a/src/lib/relaticle.ts
+++ b/src/lib/relaticle.ts
@@ -64,15 +64,16 @@ export type CrmResult = {
 };
 
 const TOPIC_LABELS: Record<string, string> = {
-  enterprise: "Enterprise / consortium",
-  investor: "Investor",
+  enterprise: "Hologram Cloud / enterprise deployment",
+  sales: "Plans & subscriptions",
+  partnership: "Partnership / integration",
+  build: "Developer support",
   press: "Press or analyst",
-  hiring: "Hiring",
   general: "General inquiry",
 };
 
 // Inquiry types that should also open an Opportunity (a lead in the pipeline).
-const LEAD_TOPICS = new Set(["investor", "enterprise"]);
+const LEAD_TOPICS = new Set(["enterprise", "sales", "partnership"]);
 
 // Custom-field types whose value must be sent as an array (verified against the
 // live API: email/phone/link reject scalars; text/select/rich-editor are scalar).


### PR DESCRIPTION
## Summary

The Relaticle CRM contact-form integration landed in #117 with **2060.io's inquiry list copied verbatim** (Investor, Hiring…) — corporate topics that belong on 2060.io, not the product site. This PR makes the list hologram-specific and fixes a cross-site secret collision.

## Inquiry types (form + CRM mapping)
- **Hologram Cloud: enterprise or on-premise deployment** → Opportunity (Prospecting)
- **Plans & subscriptions: pricing, quotes, billing** → Opportunity (Prospecting)
- **Partnership / integration** → Opportunity (Prospecting)
- **Building an agent: developer support**
- **Press or analyst**
- **General inquiry**

(Removed: Investor, Hiring — those route via 2060.io's contact form.)

## Secret rename: `website-secrets` → `hologram-website-secrets`
`2060.io-website` deploys to the same `web` namespace and uses `website-secrets` for **its** CRM token, so the shared name would let each site's deploy overwrite the other's token and mis-attribute records to the wrong service account. Renamed per the `<fullname>-secrets` convention (release is `hologram-website`) in `charts/values.yaml`, `cd.yml`, `deploy.yml`, and the `.env.example` comment. Safe to rename now: #117 hasn't shipped in a stable release yet, so nothing deployed references the old name.

## Verification
- `tsc` clean; `npm run build` (`/api/contact` dynamic, `/contact` static).
- End-to-end against the live CRM with the `hologram.zone` service-account token: validation → `422`; enterprise lead → `200` creating Company/Person/Note/Opportunity/Task — then deleted.

> Branched from `main` (#117 already merged).
