### PR TITLE
ci(deploy): use KUBECONFIG_2060_PROD secret for kubeconfig

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,10 +124,10 @@ jobs:
 
       - name: Write kubeconfig
         env:
-          KUBECONFIG_DATA: ${{ secrets.OVH_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_2060_PROD }}
         run: |
           if [ -z "$KUBECONFIG_DATA" ]; then
-            echo "::error::The OVH_KUBECONFIG GitHub Actions secret is empty."
+            echo "::error::The KUBECONFIG_2060_PROD GitHub Actions secret is empty."
             echo "Set it under Settings → Secrets and variables → Actions → Secrets."
             exit 1
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
 
       - name: Write kubeconfig
         env:
-          KUBECONFIG_DATA: ${{ secrets.OVH_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_2060_PROD }}
         run: |
           if [ -z "$KUBECONFIG_DATA" ]; then
-            echo "::error::The OVH_KUBECONFIG GitHub Actions secret is empty."
+            echo "::error::The KUBECONFIG_2060_PROD GitHub Actions secret is empty."
             echo "Set it under Settings → Secrets and variables → Actions → Secrets."
             exit 1
           fi


### PR DESCRIPTION
Switch the kubeconfig source from `secrets.OVH_KUBECONFIG` to `secrets.KUBECONFIG_2060_PROD` in both deploy workflows (`cd.yml` and `deploy.yml`). The diagnostic error message that names the secret is updated to match, so it stays accurate.

**Action required before merge:** the `KUBECONFIG_2060_PROD` repository secret must exist (same kubeconfig content as the old `OVH_KUBECONFIG`).