### PR TITLE
ci: wire ALERT_WEBHOOK_URL through to the pod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   resolve-version:
-    uses: 2060-io/organization/.github/workflows/resolve-version-call.yml@main
+    uses: 2060-io/organization/.github/workflows/resolve-version-call.yml@d199fdc55832f78f90158117a93d227709ca2746 # main
 
   docker:
     needs: resolve-version
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compute tags
         id: compute-tags
@@ -48,17 +48,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build & push ${{ env.IMAGE_NAME }} dev tags
         if: env.RELEASE_TYPE == 'dev'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build & push ${{ env.IMAGE_NAME }} stable release tags
         if: env.RELEASE_TYPE == 'stable'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -112,13 +112,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.14.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compute image tag
         id: tag
@@ -38,10 +38,10 @@ jobs:
           echo "Deploying io2060/hologram-website:$VERSION"
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.14.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,10 +78,12 @@ jobs:
         # kubectl (not helm) and annotated keep so helm never prunes it.
         env:
           RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
+          ALERT_WEBHOOK_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
         run: |
           kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n web create secret generic hologram-website-secrets \
             --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
+            --from-literal=ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL}" \
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl -n web annotate secret hologram-website-secrets \
             helm.sh/resource-policy=keep --overwrite

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -54,6 +54,13 @@ spec:
                   # Optional so the pod still starts if the secret is absent;
                   # the contact route degrades to best-effort (logs only).
                   optional: true
+            # Ops alert webhook (Discord-shaped); alertOps() no-ops when unset.
+            - name: ALERT_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.relaticle.secretName }}
+                  key: ALERT_WEBHOOK_URL
+                  optional: true
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
The contact route already calls `alertOps()` when a CRM write fails, but `ALERT_WEBHOOK_URL` was never delivered to the pod, so alerting was a silent no-op.

Now that the GitHub secret exists, this passes it through the deploy job's secret upsert and exposes it (optional, from the relaticle secret) in the Helm deployment template.